### PR TITLE
Made links resilient to version number changes in filename

### DIFF
--- a/roles/epel/vars/RedHat-6.yml
+++ b/roles/epel/vars/RedHat-6.yml
@@ -1,2 +1,2 @@
 ---
-epel_rpm: http://dl.fedoraproject.org/pub/epel/6/x86_64/epel-release-6-8.noarch.rpm
+epel_rpm: http://dl.fedoraproject.org/pub/epel/epel-release-latest-6.noarch.rpm

--- a/roles/epel/vars/RedHat-7.yml
+++ b/roles/epel/vars/RedHat-7.yml
@@ -1,3 +1,3 @@
 ---
-epel_rpm: http://dl.fedoraproject.org/pub/epel/7/x86_64/e/epel-release-7-5.noarch.rpm
+epel_rpm: http://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
 


### PR DESCRIPTION
Not a big deal but the link was broken as of 4th April, changed it to the 'latest' link for EPEL. 
